### PR TITLE
Parameterize service credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Senha padrão: guest
 
 Essa interface permite monitorar filas, mensagens, conexões, entre outras funcionalidades.
 
+## Variáveis de Ambiente
+Defina as seguintes variáveis para configurar credenciais e conexões:
+
+- `KONSI_API_URL` – URL para geração do token.
+- `KONSI_USERNAME` – usuário para autenticação na API Konsi.
+- `KONSI_PASSWORD` – senha da API Konsi.
+- `KONSI_API_URL_CPF` – endpoint para consulta de benefícios.
+- `RABBITMQ_HOST` – host do RabbitMQ.
+- `RABBITMQ_USER` – usuário do RabbitMQ.
+- `RABBITMQ_PASSWORD` – senha do RabbitMQ.
+- `RABBITMQ_QUEUE` – nome da fila utilizada para envio de CPFs.
+
 ## Uso da API:
 
 - Consulta de Benefícios

--- a/src/Konsi.API.ConsultarCpf/Konsi.API.ConsultarCpf/Program.cs
+++ b/src/Konsi.API.ConsultarCpf/Konsi.API.ConsultarCpf/Program.cs
@@ -19,8 +19,24 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Services.Configure<KonsiSettings>(builder.Configuration.GetSection("Konsi"));
-builder.Services.Configure<RabbitMQSettings>(builder.Configuration.GetSection("RabbitMQ"));
+
+builder.Configuration.AddEnvironmentVariables();
+
+builder.Services.Configure<KonsiSettings>(options =>
+{
+    options.ApiUrl = Environment.GetEnvironmentVariable("KONSI_API_URL") ?? builder.Configuration["Konsi:ApiUrl"];
+    options.Name = Environment.GetEnvironmentVariable("KONSI_USERNAME") ?? builder.Configuration["Konsi:name"];
+    options.Password = Environment.GetEnvironmentVariable("KONSI_PASSWORD") ?? builder.Configuration["Konsi:Password"];
+    options.ApiUrlCpf = Environment.GetEnvironmentVariable("KONSI_API_URL_CPF") ?? builder.Configuration["Konsi:ApiUrlCpf"];
+});
+
+builder.Services.Configure<RabbitMQSettings>(options =>
+{
+    options.HostName = Environment.GetEnvironmentVariable("RABBITMQ_HOST") ?? builder.Configuration["RabbitMQ:HostName"];
+    options.UserName = Environment.GetEnvironmentVariable("RABBITMQ_USER") ?? builder.Configuration["RabbitMQ:UserName"];
+    options.Password = Environment.GetEnvironmentVariable("RABBITMQ_PASSWORD") ?? builder.Configuration["RabbitMQ:Password"];
+    options.QueueName = Environment.GetEnvironmentVariable("RABBITMQ_QUEUE") ?? builder.Configuration["RabbitMQ:QueueName"];
+});
 builder.Services.Configure<RedisSettings>(builder.Configuration.GetSection("Redis"));
 var redisConnectionString = builder.Configuration.GetSection("Redis:ConnectionString").Value ?? "localhost";
 

--- a/src/Konsi.API.ConsultarCpf/Konsi.API.ConsultarCpf/appsettings.json
+++ b/src/Konsi.API.ConsultarCpf/Konsi.API.ConsultarCpf/appsettings.json
@@ -8,16 +8,16 @@
   },
   "AllowedHosts": "*",
   "Konsi": {
-    "ApiUrl": "http://teste-dev-api-dev-140616584.us-east-1.elb.amazonaws.com/api/v1/token",
-    "name": "test@konsi.com.br",
-    "Password": "Test@Konsi2023*",
-    "ApiUrlCpf": "http://teste-dev-api-dev-140616584.us-east-1.elb.amazonaws.com/api/v1/inss/consulta-beneficios/"
+    "ApiUrl": "KONSI_API_URL",
+    "name": "KONSI_USERNAME",
+    "Password": "KONSI_PASSWORD",
+    "ApiUrlCpf": "KONSI_API_URL_CPF"
   },
   "RabbitMQ": {
-    "HostName": "localhost",
-    "UserName": "guest",
-    "Password": "guest",
-    "QueueName": "cpf_queue"
+    "HostName": "RABBITMQ_HOST",
+    "UserName": "RABBITMQ_USER",
+    "Password": "RABBITMQ_PASSWORD",
+    "QueueName": "RABBITMQ_QUEUE"
   },
   "Redis": {
     "ConnectionString": "localhost"


### PR DESCRIPTION
## Summary
- use environment variables for RabbitMQ and Konsi credentials
- load env vars in Program.cs
- document the new variables

## Testing
- `dotnet test src/Tests/Tests.csproj -c Release` *(fails: missing .NET 7 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_684249edc88c8333a9887b6294edb244